### PR TITLE
HH-73773 В правиле stylelint-order изменить порядок проверки свойств

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 ## История изменений
 
+
+### 2.0.3
+
+- В правиле `stylelint-order` изменён порядок перечисления свойств. Less-mixins добавлены перед declarations.
+- Подняли версию плагина `stylelint-order`
+
 ### 2.0.2
 
 - Исправлен баг в значении `ignoreProperties` правила `value-keyword-case`

--- a/index.js
+++ b/index.js
@@ -265,7 +265,15 @@ module.exports = {
         "scss/selector-no-redundant-nesting-selector": true,
 
         "order/order": [
-            ["at-variables", "declarations", "rules", "at-rules"],
+            "at-variables",
+            // Для обработки less-миксинов вида .my-mixin()
+            {
+                type: "rule",
+                selector: /^\.[\w-_]+\((.+)?\)$/
+            },
+            "declarations",
+            "rules",
+            "at-rules"
         ],
 
         "plugin/value-list-box-shadow-inset-first": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hh.ru/stylelint-config-hh",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "HH.ru config for stylelint",
   "main": "index.js",
   "repository": {
@@ -15,7 +15,7 @@
   "dependencies": {
     "lodash": "~4.17.4",
     "stylelint": "~8.2.0",
-    "stylelint-order": "~0.4.3",
+    "stylelint-order": "~0.7.0",
     "stylelint-scss": "~1.4.4",
     "stylelint-value-list-box-shadow-inset-first": "~1.0.1"
   }


### PR DESCRIPTION
https://jira.hh.ru/browse/HH-73773

В hh.sites.main и bloko мы используем less-миксины для абстракции некоторых наборов свойств в отдельные сущности, которые впоследствии переопределяем. 
Плагин `stylelint-order` считает less-миксины вложенными правилами (rules), которые должны перечисляться после declarations (например, margin: 0;). В данной задаче, вносится уточнение rules для less-миксинов, которое позволяет писать их перед declarations.

Изменения в данной задаче позволяют писать правила вида:

```
.custom-class {
       // less-mixin 
       .custom-font();
       
       // override custom-font
        color: #fff;
        font-size: 45px;
}
```