### PR TITLE
HH-74019 Add check for font-family value

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 ## История изменений
 
+### 2.0.6
+
+- В правило `declaration-property-value-whitelist` добавлена проверка свойства `font-family`. Разрешенные значения: `inherit`, `initial`, `unset` и less-переменные.
+
 ### 2.0.5
 
 - Добавили единицу измерения vh в `unit-whitelist`

--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ module.exports = {
             "font-style": ["inherit", "initial", "unset", "italic", "normal", "/^@/"],
             //"z-index": ["inherit", "initial", "unset", "/^@/"]
             //"font-size": ["inherit", "initial", "unset", "/^@/"]
-            //"font-family": ["inherit", "initial", "unset", "/^@/"]
+            "font-family": ["inherit", "initial", "unset", "/^@/"]
         },
         "declaration-property-value-blacklist": {
             "/^border/": ["/\\bnone\\b/"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hh.ru/stylelint-config-hh",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "HH.ru config for stylelint",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
https://jira.hh.ru/browse/HH-74019

- В правило declaration-property-value-whitelist добавлена проверка свойства font-family. Разрешенные значения: inherit, initial, unset и less-переменные.