### PR TITLE
HH-133415 add conditions for colors to declaration-property-value-disallowed-list

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 ## История изменений
 
+### 4.1.2
+
+- В правило `declaration-property-value-disallowed-list` добавлена проверка, запрещающая использовать цвета HEX, RGBA и HSLA напрямую
+
 ### 4.1.1
 
 - Добавлено начертание 800 в font-weight declaration-property-value-allowed-list

--- a/index.js
+++ b/index.js
@@ -1,3 +1,7 @@
+const HEX_REGEX = new RegExp(/#[\da-f]{3,6}/);
+const RGBA_REGEX = new RegExp(/rgba?\(/);
+const HSLA_REGEX = new RegExp(/hsla?\(/);
+
 module.exports = {
     "plugins": [
         "stylelint-scss",
@@ -106,7 +110,13 @@ module.exports = {
             "font-family": ["inherit", "initial", "unset", "/^@/"]
         },
         "declaration-property-value-disallowed-list": {
-            "/^border/": ["/\\bnone\\b/"]
+            "/^border/": ["/\\bnone\\b/"],
+            "/color$/": [HEX_REGEX, RGBA_REGEX, HSLA_REGEX],
+            "/background/": [HEX_REGEX, RGBA_REGEX, HSLA_REGEX],
+            "/border/": [HEX_REGEX, RGBA_REGEX, HSLA_REGEX],
+            "/box-shadow/": [HEX_REGEX, RGBA_REGEX, HSLA_REGEX],
+            "/fill/": [HEX_REGEX, RGBA_REGEX, HSLA_REGEX],
+            "/stroke/": [HEX_REGEX, RGBA_REGEX, HSLA_REGEX]
         },
 
         "declaration-block-no-duplicate-properties": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hh.ru/stylelint-config-hh",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "HH.ru config for stylelint",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
https://jira.hh.ru/browse/HH-133415

Расширить правило `declaration-property-value-disallowed-list` условиями для запрета использовать цвета напрямую

Из Bloko и xhh будут в последствии удалены подобные условия
https://github.com/hhru/bloko/blob/master/.stylelintrc.js#L4
https://github.com/hhru/hh.sites.main/blob/master/.stylelintrc.js#L9
