### PR TITLE
HH-142828 don't allow to use transparent in gradient

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 ## История изменений
 
+### 8.0.0
+
+В правило `declaration-property-value-disallowed-list` для свойства `background` добавлена проверка, не позволяющая использовать `transparent` внутри `gradient` 
+
 ### 7.0.0
 
 Добавлено правило less-variable-value-disallowed-list, позволяющее запретить некоторые значения для less-переменных

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const HEX_REGEX = new RegExp(/#[\da-f]{3,6}/);
 const RGBA_REGEX = new RegExp(/rgba?\(/);
 const HSLA_REGEX = new RegExp(/hsla?\(/);
+const NO_TRANSPARENT_IN_GRADIENT_REGEX = new RegExp(/gradient.+?transparent/);
 
 module.exports = {
     "plugins": [
@@ -107,7 +108,7 @@ module.exports = {
         "declaration-property-value-disallowed-list": {
             "/^border/": [HEX_REGEX, RGBA_REGEX, HSLA_REGEX, "/\\bnone\\b/"],
             "/color$/": [HEX_REGEX, RGBA_REGEX, HSLA_REGEX],
-            "/background/": [HEX_REGEX, RGBA_REGEX, HSLA_REGEX],
+            "/background/": [HEX_REGEX, RGBA_REGEX, HSLA_REGEX, NO_TRANSPARENT_IN_GRADIENT_REGEX],
             "/box-shadow/": [HEX_REGEX, RGBA_REGEX, HSLA_REGEX],
             "/fill/": [HEX_REGEX, RGBA_REGEX, HSLA_REGEX],
             "/stroke/": [HEX_REGEX, RGBA_REGEX, HSLA_REGEX]


### PR DESCRIPTION
https://jira.hh.ru/browse/HH-142828

Разные браузеры по-разному интерпретируют `transparent` (где-то это белый, где-то черный), это стреляет в градиентах
Надо добавить правило не позволять использование `transparent` в `gradient`
