### PR TITLE
HH-235533 Up stylelint, remove deprecated rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,6 @@ module.exports = {
         "./plugins/hhru"
     ],
     "rules": {
-        "color-hex-case": "lower",
         "color-hex-length": "short",
         "color-named": "never",
         "color-no-invalid-hex": true,
@@ -22,32 +21,20 @@ module.exports = {
         "font-weight-notation": "named-where-possible",
 
         "function-calc-no-unspaced-operator": true,
-        "function-comma-newline-after": "always-multi-line",
-        "function-comma-newline-before": "never-multi-line",
-        "function-comma-space-after": "always-single-line",
-        "function-comma-space-before": "never-single-line",
         "function-linear-gradient-no-nonstandard-direction": true,
-        "function-max-empty-lines": 0,
         "function-name-case": "lower",
-        "function-parentheses-newline-inside": "always-multi-line",
-        "function-parentheses-space-inside": "never-single-line",
         "function-url-scheme-disallowed-list": ["data", "/[A-Z]/"],
         "function-url-no-scheme-relative": true,
         "function-url-quotes": "always",
-        "function-whitespace-after": "always",
 
-        "number-leading-zero": "always",
         "number-max-precision": 4,
-        "number-no-trailing-zeros": true,
 
         "string-no-newline": true,
-        "string-quotes": "single",
 
         "length-zero-no-unit": true,
 
         "time-min-milliseconds": 100,
 
-        "unit-case": "lower",
         "unit-no-unknown": true,
         "unit-allowed-list": [
             "px",
@@ -66,25 +53,15 @@ module.exports = {
                 "ignoreProperties": ["/^\@?font-family/"],
             }
         ],
-        "value-list-comma-newline-after": "always-multi-line",
-        "value-list-comma-newline-before": "never-multi-line",
-        "value-list-comma-space-after": "always-single-line",
-        "value-list-comma-space-before": "never",
-        "value-list-max-empty-lines": 0,
 
         "shorthand-property-no-redundant-values": true,
 
         "property-disallowed-list": ["font"],
-        "property-case": "lower",
         "property-no-unknown": true,
 
         "keyframe-declaration-no-important": true,
         "keyframes-name-pattern": /^[a-z0-9-]+$/,
 
-        "declaration-bang-space-after": "never",
-        "declaration-bang-space-before": "always",
-        "declaration-colon-space-after": "always-single-line",
-        "declaration-colon-space-before": "never",
         "declaration-empty-line-before": [
             "always",
             {
@@ -131,20 +108,7 @@ module.exports = {
 
         "declaration-block-no-duplicate-properties": true,
         "declaration-block-no-shorthand-property-overrides": true,
-        "declaration-block-semicolon-newline-after": "always",
-        "declaration-block-semicolon-newline-before": "never-multi-line",
-        "declaration-block-semicolon-space-before": "never",
-        "declaration-block-trailing-semicolon": "always",
 
-        "block-closing-brace-empty-line-before": "never",
-        "block-closing-brace-newline-after": "always",
-        "block-closing-brace-newline-before": "always-multi-line",
-        "block-opening-brace-newline-after": "always",
-        "block-opening-brace-space-before": "always",
-
-        "selector-attribute-brackets-space-inside": "never",
-        "selector-attribute-operator-space-after": "never",
-        "selector-attribute-operator-space-before": "never",
         "selector-attribute-quotes": "always",
         "selector-class-pattern": [
             /*
@@ -158,9 +122,6 @@ module.exports = {
                 "resolveNestedSelectors": true
             }
         ],
-        "selector-combinator-space-after": "always",
-        "selector-combinator-space-before": "always",
-        "selector-descendant-combinator-no-non-space": true,
         "selector-max-compound-selectors": 3,
         "selector-max-id": 0,
         "selector-nested-pattern": [
@@ -178,7 +139,6 @@ module.exports = {
             }
         ],
         "selector-max-universal": 0,
-        "selector-pseudo-class-case": "lower",
         "selector-pseudo-class-no-unknown": [
             true,
             {
@@ -186,16 +146,10 @@ module.exports = {
                 "ignorePseudoClasses": ["global"]
             }
         ],
-        "selector-pseudo-class-parentheses-space-inside": "never",
-        "selector-pseudo-element-case": "lower",
         "selector-pseudo-element-colon-notation": "double",
         "selector-pseudo-element-no-unknown": true,
         "selector-type-case": "lower",
         "selector-type-no-unknown": true,
-        "selector-max-empty-lines": 0,
-
-        "selector-list-comma-newline-after": "always",
-        "selector-list-comma-space-before": "never",
 
         "rule-empty-line-before": [
             "always",
@@ -210,16 +164,7 @@ module.exports = {
             }
         ],
 
-        "media-feature-colon-space-after": "always",
-        "media-feature-colon-space-before": "never",
-        "media-feature-name-case": "lower",
         "media-feature-name-no-unknown": true,
-        "media-feature-parentheses-space-inside": "never",
-        "media-feature-range-operator-space-after": "always",
-        "media-feature-range-operator-space-before": "always",
-
-        "media-query-list-comma-newline-after": "always",
-        "media-query-list-comma-space-before": "never",
 
         "at-rule-empty-line-before": [
             "always",
@@ -234,11 +179,7 @@ module.exports = {
                 ]
             }
         ],
-        "at-rule-name-case": "lower",
-        "at-rule-name-space-after": "always-single-line",
         "at-rule-no-unknown": true,
-        "at-rule-semicolon-newline-after": "always",
-        "at-rule-semicolon-space-before": "never",
         "at-rule-allowed-list": ["media", "keyframes", "import"],
 
         "comment-empty-line-before": [
@@ -255,19 +196,6 @@ module.exports = {
         "comment-no-empty": true,
         "comment-whitespace-inside": "always",
 
-        /*
-        "indentation": [
-            4,
-            {
-                "ignore": [
-                    "param",
-                    "value"
-                ]
-            }
-        ],
-        */
-        "max-empty-lines": 2,
-        "max-line-length": 120,
         "max-nesting-depth": [
             2,
             {
@@ -281,15 +209,10 @@ module.exports = {
         */
         "no-duplicate-at-import-rules": true,
         "no-duplicate-selectors": true,
-        "no-empty-first-line": true,
         "no-empty-source": true,
-        "no-eol-whitespace": true,
-        "no-extra-semicolons": true,
         "no-invalid-double-slash-comments": true,
-        "no-missing-end-of-source-newline": true,
         "no-unknown-animations": true,
 
-        "scss/at-import-partial-extension-blacklist": ["less"],
         "scss/double-slash-comment-whitespace-inside": "always",
         "scss/double-slash-comment-empty-line-before": [
             "always",
@@ -306,9 +229,6 @@ module.exports = {
             "rules",
             "at-rules"
         ],
-
-        "linebreaks": "unix",
-        "unicode-bom": "never",
 
         // @kebab-case-variables-only
         "hhru/less-variable-name-pattern": "^_?[a-z]+[a-z0-9]*(?:-[a-z0-9]+)*$",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "lodash": "~4.17.21"
   },
   "peerDependencies": {
-    "stylelint": "~13.13.1",
-    "stylelint-order": "~4.1.0",
-    "stylelint-scss": "~3.19.0"
+    "stylelint": ">=16.9.0",
+    "stylelint-order": ">=6.0.4",
+    "stylelint-scss": ">=6.7.0"
   },
   "scripts": {
     "release": "npm publish --access=public"


### PR DESCRIPTION
https://jira.hh.ru/browse/HH-235533

Многие правила по форматированию стали deprecated в 15 и удалились в 16, они переехали в плагин prettier, который теперь отвечает за форматирование