### PR TITLE
HH-237422 feat(plugin)!: magritte import replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 ## История изменений
 
+### 13.0.0
+
+Запрещен импорт magritte-design-tokens, magritte-reset-css, magritte-fonts. Используйте magritte-ui.
 
 ### 11.0.0
 

--- a/index.js
+++ b/index.js
@@ -236,6 +236,13 @@ module.exports = {
         // no colors in variables
         "hhru/less-variable-value-disallowed-list": {
             '*': [HEX_REGEX, RGBA_REGEX, HSLA_REGEX],
-        }
+        },
+
+        'hhru/less-import-replacement': [
+            // Unified magritte imports
+            [/@hh\.ru\/magritte-design-tokens(\/.*)/, '@hh.ru/magritte-ui$1'],
+            [/@hh\.ru\/magritte-reset-css\/reset\.css/, '@hh.ru/magritte-ui/reset'],
+            [/@hh\.ru\/magritte-fonts\/fonts\.css/, '@hh.ru/magritte-ui/fonts']
+        ]
     },
 };

--- a/plugins/hhru/index.js
+++ b/plugins/hhru/index.js
@@ -1,5 +1,5 @@
 const lessVariableNamePattern = require('./rules/less-variable-name-pattern');
 const lessVariableValueDisallowedList = require('./rules/less-variable-value-disallowed-list');
+const lessImportReplacement = require('./rules/less-import-replacement');
 
-
-module.exports = [ lessVariableNamePattern, lessVariableValueDisallowedList];
+module.exports = [lessVariableNamePattern, lessVariableValueDisallowedList, lessImportReplacement];

--- a/plugins/hhru/rules/less-import-replacement.js
+++ b/plugins/hhru/rules/less-import-replacement.js
@@ -1,0 +1,61 @@
+const stylelint = require("stylelint");
+const _ = require('lodash');
+
+const ruleName = 'hhru/less-import-replacement';
+const messages = stylelint.utils.ruleMessages(ruleName, {
+    expected: (actual, expected) => `Expected import ${actual} to be replaced with import ${expected}`,
+});
+
+const ruleFunction = (options) => {
+    return (root, result) => {
+        const validOptions = stylelint.utils.validateOptions(result, ruleName, {
+            actual: options,
+            possible: [
+                _.isArray,
+            ],
+        });
+        if (!validOptions) {
+            return;
+        }
+
+        const replacements = options.map(([matcher, replacement]) => _.isString(matcher) ? [new RegExp(matcher), replacement] : [matcher, replacement])
+
+        root.walkAtRules('import', (atRule) => {
+            const importStatement = atRule.params
+
+            for (const [pattern, replacement] of replacements) {
+                if (!pattern.test(importStatement)) {
+                    continue
+                }
+
+                const suggestedReplacement = importStatement.replace(pattern, replacement);
+                stylelint.utils.report({
+                    message: messages.expected(importStatement, suggestedReplacement),
+                    node: atRule,
+                    result,
+                    ruleName,
+                    fix: () => {
+                        const newNode = atRule.clone();
+                        newNode.params =
+                            (newNode.raws.afterName ?? ' ') +
+                            suggestedReplacement;
+                        newNode.raws.afterName = ' ';
+                        atRule.replaceWith(newNode);
+                    }
+                });
+                break;
+            }
+        });
+    };
+}
+
+ruleFunction.ruleName = ruleName;
+ruleFunction.messages = messages;
+ruleFunction.meta = {
+    fixable: true
+}
+ruleFunction.primaryOptionArray = true;
+
+module.exports = stylelint.createPlugin(ruleName, ruleFunction);
+
+


### PR DESCRIPTION
Описание в задаче https://jira.hh.ru/browse/HH-237422

Процесс миграции простой - запустить autofix. Возможно нужно запустить дважды, так как после автофикса импорты могут задублироваться (если уже был импорта magritte-ui)